### PR TITLE
Add python-neutronclient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:latest
 ENV OS_CLOUD=""
-RUN pip install python-openstackclient python-heatclient
+RUN pip install python-openstackclient python-heatclient python-neutronclient
 VOLUME /etc/openstack
 WORKDIR /etc/openstack
 ENTRYPOINT [ "/bin/bash", "-c" ]


### PR DESCRIPTION
I realise it's deprecated, but there doesn't seem to be another way to control a LBaaS :(

https://docs.openstack.org/python-openstackclient/latest/cli/decoder.html#neutron-cli